### PR TITLE
Update nostter URL

### DIFF
--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -34,8 +34,8 @@ export const clients: Client[] = [
     name: 'nostter',
     imgsrc:
       'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f43e.svg',
-    url_user: 'https://nostter.vercel.app/',
-    url_note: 'https://nostter.vercel.app/',
+    url_user: 'https://nostter.app/',
+    url_note: 'https://nostter.app/',
     nip05: false,
     smartphone: false,
   },


### PR DESCRIPTION
Recently nostter moved to https://nostter.app.

Maybe we should also update the logo in the link button?