### PR TITLE
READMEをプロダクト説明に書き換え

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,79 @@
-# create-svelte
+# Nostx
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte).
+**Nostrの世界をシームレスに**
 
-## Creating a project
+https://nostx.io
 
-If you're seeing this, you've probably already done this step. Congrats!
+Nostx は、Nostr で使われる NIP-19 形式のコード（`npub` / `nprofile` / `note` / `nevent`）や NIP-05 アドレスを読み取り、各 Nostr クライアントで開けるリンクに変換するシェアゲートウェイです。クライアントの垣根を越えて、プロフィールや投稿を簡単に共有できます。
 
-```bash
-# create a new project in the current directory
-npm create svelte@latest
+## 主な機能
 
-# create a new project in my-app
-npm create svelte@latest my-app
+- **NIP-19 コードの変換**: `npub1...` / `nprofile1...` / `note1...` / `nevent1...` を各クライアントのリンクに変換
+- **NIP-05 アドレス対応**: `name@example.com` 形式のアドレスからプロフィールを解決
+- **プレビュー表示**: 変換前にプロフィールや投稿の内容をプレビュー
+- **QR コード生成**: `https://nostx.io/...` 形式の共有用 QR コードを生成
+- **Zap 送金**: Lightning Address（LUD-16）から LNURL 経由でインボイスを生成し、`lightning:` スキームで送金
+- **多言語対応**: 日本語 / 英語（svelte-i18n）
+
+## 対応クライアント
+
+| クライアント | 方式 |
+| --- | --- |
+| アプリで開く | `nostr:` スキーム（ネイティブアプリ連携） |
+| [Primal](https://primal.net/) | Web リンク |
+| [Coracle](https://coracle.social/) | Web リンク |
+| [Iris](https://iris.to/) | Web リンク |
+| [Snort](https://snort.social/) | Web リンク |
+| [nostter](https://nostter.app/) | Web リンク |
+| [Lumilumi](https://lumilumi.app/) | Web リンク |
+
+## 使い方
+
+トップページ（https://nostx.io ）の入力欄に NIP-19 コードを貼り付けるか、URL に直接コードを付けてアクセスします。
+
+```
+https://nostx.io/{npub | nprofile | note | nevent | NIP-05アドレス}
 ```
 
-## Developing
+例:
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+```
+https://nostx.io/npub1xxxxxxxx...
+https://nostx.io/nevent1xxxxxxxx...
+https://nostx.io/name@example.com
+```
+
+開いたページでプレビューを確認し、開きたいクライアントを選択するだけです。
+
+QR コードを作りたい場合は https://nostx.io/qr から生成できます。
+
+## 開発
+
+### 技術スタック
+
+- [SvelteKit 2](https://kit.svelte.dev/) + [Svelte 5](https://svelte.dev/)
+- [nostr-tools](https://github.com/nbd-wtf/nostr-tools)
+- [svelte-i18n](https://github.com/kaisermann/svelte-i18n)
+
+### セットアップ
 
 ```bash
+# 依存関係のインストール
+npm install
+
+# 開発サーバーの起動
 npm run dev
 
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
-
-## Building
-
-To create a production version of your app:
-
-```bash
+# プロダクションビルド
 npm run build
+
+# 型チェック
+npm run check
+
+# Lint
+npm run lint
 ```
 
-You can preview the production build with `npm run preview`.
+## ライセンス
 
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+[LICENSE.md](./LICENSE.md) を参照してください。


### PR DESCRIPTION
## 概要
create-svelte のテンプレートのままだった README.md を、Nostx のプロダクト説明に書き換えました。

## 記載内容
- プロダクト概要（NIP-19 / NIP-05 → 各クライアントリンクへの変換ゲートウェイ）
- 主な機能（変換、プレビュー、QR コード生成、Zap 送金、多言語対応）
- 対応クライアント一覧（nostr: スキーム / Primal / Coracle / Iris / Snort / nostter / Lumilumi）
- 使い方（URL 形式と例）
- 開発手順（npm install / dev / build / check / lint）
- ライセンス（LICENSE.md 参照）

## 補足
- 日本語 README のみ（英語版は将来の別 Issue で対応）
- スクリーンショットは今回含めていません
- 変更ファイルは README.md のみです

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112RQaexN6atEs2mLKwrynY